### PR TITLE
Squashed Disjointed Tire Bug

### DIFF
--- a/Assets/ScriptableObjects/Karts/RedKart.asset
+++ b/Assets/ScriptableObjects/Karts/RedKart.asset
@@ -18,5 +18,5 @@ MonoBehaviour:
   steeringAngleLimit: 30
   timeToRotate: 0.75
   tireGrip: 0.75
-  speed: 200
+  speed: 100
   tireRadius: 1.1

--- a/Assets/Scripts/KartAnimation.cs
+++ b/Assets/Scripts/KartAnimation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+
 public class KartAnimation : MonoBehaviour
 {
     [SerializeField] private ScriptableKart kart;
@@ -12,20 +13,37 @@ public class KartAnimation : MonoBehaviour
     public void UpdateTireRotation(int index, float y)
     {
         if (suspensionPoints.ContainsKey(index))
-            tireGFX[index].localEulerAngles = new Vector3(tireGFX[index].localEulerAngles.x, y, tireGFX[index].localEulerAngles.z);
+            tireGFX[index].localEulerAngles = new Vector3
+            (
+                tireGFX[index].localEulerAngles.x,
+                y,
+                tireGFX[index].localEulerAngles.z
+            );
     }
 
     public void UpdateTirePosition(int index, float x, float z)
     {
         if (suspensionPoints.ContainsKey(index))
-            tireGFX[index].position = new Vector3(x, suspensionPoints[index], z);
+            tireGFX[index].localPosition = new Vector3
+            (
+                x,
+                suspensionPoints[index],
+                z
+            );
     }
 
-    public void UpdateSuspensionPoint(int index, float point)
+    public void UpdateSuspensionPoint(int index, RaycastHit hit)
     {
+        Vector3 local = transform.InverseTransformPoint(hit.point);
+        
         if (!suspensionPoints.ContainsKey(index))
-            suspensionPoints.Add(index, point);
+            suspensionPoints.Add(index, hit.point.y);
         else
-            suspensionPoints[index] = point + kart.TireRadius;
+        {
+            if (hit.collider != null)
+                suspensionPoints[index] = local.y + kart.TireRadius;
+            else
+                suspensionPoints[index] = kart.TireRadius;
+        }
     }
 }

--- a/Assets/Scripts/KartLocomotion.cs
+++ b/Assets/Scripts/KartLocomotion.cs
@@ -40,14 +40,14 @@ public class KartLocomotion : MonoBehaviour
         foreach (Transform tire in tires)
         {
             RaycastHit hit;
-            Ray ray = new(tire.transform.position, -Vector3.up);
+            Ray ray = new(tire.position, -Vector3.up);
             if (Physics.Raycast(ray, out hit, kart.SuspensionLength))
             {
                 CalculateSuspension(tire, hit);
                 CancelSidewaysForce(tire);
                 Accelerate(tire);
-                animator.UpdateSuspensionPoint(tires.IndexOf(tire), hit.point.y);
             }
+            animator.UpdateSuspensionPoint(tires.IndexOf(tire), hit);
         }
         foreach (Transform tire in frontTires)
             AdjustSteeringAngle(tire);
@@ -57,7 +57,7 @@ public class KartLocomotion : MonoBehaviour
             if (i < frontTires.Count)
                 animator.UpdateTireRotation(i, frontTires[i].localEulerAngles.y);
 
-            animator.UpdateTirePosition(i, tires[i].position.x, tires[i].position.z);
+            animator.UpdateTirePosition(i, tires[i].localPosition.x, tires[i].localPosition.z);
         }
     }
 


### PR DESCRIPTION
The bug in question occurred when one of the sides of the car was not touching the ground. The reason being I was using world coords to calculate the position of the tire when I should've been using local coords AND the raycast hit returned {0,0,0} when the raycast hit nothing, causing the position of the tires to be incorrect. So, for example, if hit.collider = null (meaning the raycast didn't hit anything, I'd have a point value of {0,0,0}. ie: the world origin. Since I was setting the world position of the tires, the tires try to stick closer to y = 0 when the car is off the ground. However, changing it to local values resulted in the opposite problem, where the tires appeared to start flying above the car when the car was airborne. Again, this is because hit.point, when collider = null, was the world origin, so when converting this to local coords, the y value was a high value relative to the car's position.

Should also lerp the values smoothly so they don't snap awkwardly to the position, but for now, it's fine.